### PR TITLE
Do not use deprecated clamp() extension

### DIFF
--- a/Sources/MicrotonalAudioKit/TuningTable.swift
+++ b/Sources/MicrotonalAudioKit/TuningTable.swift
@@ -221,7 +221,11 @@ public class TuningTable: TuningTableBase {
             let lp2 = pow(2, ttOctaveFactor)
 
             var f = tone * lp2 * middleCFrequency
-            f = (0 ... TuningTable.NYQUIST).clamp(f)
+            if f < 0 {
+                f = 0
+            } else if f > TuningTable.NYQUIST {
+                f = TuningTable.NYQUIST
+            }
             tableData[i] = Frequency(f)
 
             // UPDATE etNNPitchBend


### PR DESCRIPTION
Replaces previous PR (wrong branch)

The current MicrotonalAudioKit package published at SPM is broken, this PR fixes the issue.